### PR TITLE
Update repo.js

### DIFF
--- a/src/routes/species/repo.js
+++ b/src/routes/species/repo.js
@@ -4,26 +4,26 @@ import { loadQueryFiles, rewriteNullAsObj } from '../../utils/pgpUtils.js'
 const SpeciesRepo = ({ db, pgp }) => {
   const qf = loadQueryFiles(join(import.meta.url, './sql'))
 
-  const getAll = async () => {
+  const getAll = () => {
     const sql = 'select * from species'
-    return await db.manyOrNone(sql)
+    return db.manyOrNone(sql)
   }
 
-  const getById = async ({ id }) => {
+  const getById = ({ id }) => {
     const sql = 'select * from species where id = $<id>'
-    const rows = await db.oneOrNone(
+    return db.oneOrNone(
       sql,
       { id },
       rewriteNullAsObj
     )
-
-    return rows
   }
 
-  const getFishEntries = async ({ id, limit, offset }) => {
-    const fishEntriesSql = pgp.as.format(qf.fishEntries, { id, limit, offset })
-    const countSql = pgp.as.format('select count(*) from fish_entries where species_id = $<id>', { id })
-    const concat = pgp.helpers.concat([fishEntriesSql, countSql])
+  const getFishEntries = async ({ id, limit, offset }) => {   
+    const queries = [
+      { query: qf.fishEntries, values: { id, limit, offset }},
+      { query: 'select count(*) from fish_entries where species_id = $<id>', values: { id }}
+    ];
+    const concat = pgp.helpers.concat(queries)
 
     const [fishEntries, total] = await db.multi(concat)
     return {


### PR DESCRIPTION
* `concat` formats queries for you automatically, no need using `pgp.as.format` explicitly.
* it is an anti-pattern resolving async calls without any need.